### PR TITLE
Fix database hijacking

### DIFF
--- a/cronjob.php
+++ b/cronjob.php
@@ -17,7 +17,9 @@ else {
 }
 
 if (! empty($options['database'])) {
-    Model\Database\select($options['database']);
+    if (! Model\Database\select($options['database'])) {
+        die("Database ".$options['database']." not found\r\n");
+    }
 }
 
 $limit = ! empty($options['limit']) && ctype_digit($options['limit']) ? (int) $options['limit'] : Model\Feed\LIMIT_ALL;

--- a/fever/index.php
+++ b/fever/index.php
@@ -30,7 +30,13 @@ function response(array $response)
 function auth()
 {
     if (! empty($_GET['database'])) {
-        Model\Database\select($_GET['database']);
+        if (! Model\Database\select($_GET['database'])) {
+            // return unauthorized if the requested database could not be found
+            return array(
+                'api_version' => 3,
+                'auth' => 0,
+            );
+        }
     }
 
     $credentials = Database::get('db')->table('config')

--- a/models/database.php
+++ b/models/database.php
@@ -36,9 +36,25 @@ function select($filename = '')
 {
     static $current_filename = DB_FILENAME;
 
-    if (ENABLE_MULTIPLE_DB && $filename !== '' && in_array($filename, get_all())) {
-        $current_filename = $filename;
-        $_SESSION['config'] = \Model\Config\get_all();
+    // function gets called with a filename at least once the database
+    // connection is established
+    if ($filename !== '') {
+        if (ENABLE_MULTIPLE_DB && in_array($filename, get_all())) {
+            $current_filename = $filename;
+
+            // unset the authenticated flag if the database is changed
+            if (empty($_SESSION['database']) || $_SESSION['database'] !== $filename) {
+                if (isset($_SESSION)) {
+                    unset($_SESSION['user']);
+                }
+
+                $_SESSION['database'] = $filename;
+                $_SESSION['config'] = \Model\Config\get_all();
+            }
+        }
+        else {
+            return false;
+        }
     }
 
     return $current_filename;

--- a/models/remember_me.php
+++ b/models/remember_me.php
@@ -67,7 +67,6 @@ function authenticate()
 
             // Create the session
             $_SESSION['user'] = User\get($record['username']);
-            $_SESSION['config'] = Config\get_all();
 
             return true;
         }
@@ -124,11 +123,12 @@ function remove($session_id)
  */
 function destroy()
 {
+    // delete the cookie without any conditions!
+    delete_cookie();
+
     $credentials = read_cookie();
 
     if ($credentials !== false) {
-
-        delete_cookie();
 
         Database::get('db')
              ->table(TABLE)
@@ -233,7 +233,9 @@ function decode_cookie($value)
 {
     @list($database, $token, $sequence) = explode('|', $value);
 
-    DatabaseModel\select(base64_decode($database));
+    if (! DatabaseModel\select(base64_decode($database))) {
+        return false;
+    }
 
     return array(
         'token' => $token,

--- a/models/user.php
+++ b/models/user.php
@@ -10,18 +10,15 @@ use Model\RememberMe;
 use Model\Database as DatabaseModel;
 
 // Check if the user is logged
-function is_logged()
+function is_loggedin()
 {
     return ! empty($_SESSION['user']);
 }
 
-// Check if the logged user is the right one
-function is_user_session()
+function logout()
 {
-    return Database::get('db')
-        ->table('config')
-        ->eq('username', $_SESSION['user']['username'])
-        ->count() === 1;
+    \Model\RememberMe\destroy();
+    \PicoFarad\Session\close();
 }
 
 // Get a user by username


### PR DESCRIPTION
Right now its still possible to hijack other databases if the username is the same in both.

1. login to a second database, remove second database => default database is active
2. login to any database and call ?action=select-db&database=<otherdatabase.sqlite>

This fix is tested for a few hours with:
- remember me (after setting session cookie to session lifetime only)
- simple login (single database & multiple databases)
- fever api (single database & multiple databases)
- cronjob  (single database & multiple databases)
- change username/password
- auto create the default database

This fixes #261 and partially reverts e9685cf.