### PR TITLE
improve image-proxy

### DIFF
--- a/controllers/common.php
+++ b/controllers/common.php
@@ -74,12 +74,6 @@ Router\get_action('more', function() {
 
 // Image proxy (avoid SSL mixed content warnings)
 Router\get_action('proxy', function() {
-    list($content, $type) = Model\Proxy\download(rawurldecode(Request\param('url')));
-
-    if (empty($content)) {
-        Response\text('Not Found', 404);
-    }
-
-    Response\content_type($type);
-    Response\raw($content);
+    Model\Proxy\download(rawurldecode(Request\param('url')));
+    exit;
 });

--- a/controllers/feed.php
+++ b/controllers/feed.php
@@ -158,9 +158,9 @@ Router\action('subscribe', function() {
         }
     }
 
-    $values += array('download_content' => 0, 'rtl' => 0);
+    $values += array('download_content' => 0, 'rtl' => 0, 'cloak_referrer' => 0);
     $url = trim($url);
-    $feed_id = Model\Feed\create($url, $values['download_content'], $values['rtl']);
+    $feed_id = Model\Feed\create($url, $values['download_content'], $values['rtl'], $values['cloak_referrer']);
 
     if ($feed_id) {
         Session\flash(t('Subscription added successfully.'));

--- a/locales/cs_CZ/translations.php
+++ b/locales/cs_CZ/translations.php
@@ -235,4 +235,5 @@ return array(
     // 'Nothing to show. Enable the debug mode to see log messages.' => '',
     // 'Enable debug mode' => '',
     // 'Original link marks article as read' => '',
+    // 'Cloak the image referrer' => '',
 );

--- a/locales/de_DE/translations.php
+++ b/locales/de_DE/translations.php
@@ -235,4 +235,5 @@ return array(
     // 'Nothing to show. Enable the debug mode to see log messages.' => '',
     // 'Enable debug mode' => '',
     // 'Original link marks article as read' => '',
+    // 'Cloak the image referrer' => '',
 );

--- a/locales/es_ES/translations.php
+++ b/locales/es_ES/translations.php
@@ -235,4 +235,5 @@ return array(
     // 'Nothing to show. Enable the debug mode to see log messages.' => '',
     // 'Enable debug mode' => '',
     // 'Original link marks article as read' => '',
+    // 'Cloak the image referrer' => '',
 );

--- a/locales/fr_FR/translations.php
+++ b/locales/fr_FR/translations.php
@@ -235,4 +235,5 @@ return array(
     'Nothing to show. Enable the debug mode to see log messages.' => 'Rien à montrer. Activez le mode debug pour voir les messages de log.',
     'Enable debug mode' => 'Activer le mode debug',
     'Original link marks article as read' => 'Marquer les articles comme lu lors d\'un clic sur le lien original',
+    'Cloak the image referrer' => 'Cloak the image referrer',
 );

--- a/locales/it_IT/translations.php
+++ b/locales/it_IT/translations.php
@@ -235,4 +235,5 @@ return array(
     // 'Nothing to show. Enable the debug mode to see log messages.' => '',
     // 'Enable debug mode' => '',
     // 'Original link marks article as read' => '',
+    // 'Cloak the image referrer' => '',
 );

--- a/locales/pt_BR/translations.php
+++ b/locales/pt_BR/translations.php
@@ -235,4 +235,5 @@ return array(
     // 'Nothing to show. Enable the debug mode to see log messages.' => '',
     // 'Enable debug mode' => '',
     // 'Original link marks article as read' => '',
+    // 'Cloak the image referrer' => '',
 );

--- a/locales/zh_CN/translations.php
+++ b/locales/zh_CN/translations.php
@@ -235,4 +235,5 @@ return array(
     // 'Nothing to show. Enable the debug mode to see log messages.' => '',
     // 'Enable debug mode' => '',
     // 'Original link marks article as read' => '',
+    // 'Cloak the image referrer' => '',
 );

--- a/models/config.php
+++ b/models/config.php
@@ -32,10 +32,6 @@ function get_reader_config()
     // Filter
     $config->setFilterIframeWhitelist(get_iframe_whitelist());
 
-    if ((bool) get('image_proxy')) {
-        $config->setFilterImageProxyUrl('?action=proxy&url=%s');
-    }
-
     if ((bool) get('debug_mode')) {
         Logger::enable();
     }

--- a/models/feed.php
+++ b/models/feed.php
@@ -102,6 +102,7 @@ function update(array $values)
                 'enabled' => empty($values['enabled']) ? 0 : $values['enabled'],
                 'rtl' => empty($values['rtl']) ? 0 : $values['rtl'],
                 'download_content' => empty($values['download_content']) ? 0 : $values['download_content'],
+                'cloak_referrer' => empty($values['cloak_referrer']) ? 0 : $values['cloak_referrer'],
             ));
 }
 
@@ -148,7 +149,7 @@ function import_opml($content)
 }
 
 // Add a new feed from an URL
-function create($url, $enable_grabber = false, $force_rtl = false)
+function create($url, $enable_grabber = false, $force_rtl = false, $cloak_referrer = false)
 {
     try {
         $db = Database::get('db');
@@ -185,6 +186,7 @@ function create($url, $enable_grabber = false, $force_rtl = false)
             'last_modified' => $resource->getLastModified(),
             'last_checked' => time(),
             'etag' => $resource->getEtag(),
+            'cloak_referrer' => $cloak_referrer ? 1 : 0,
         ));
 
         if ($result) {

--- a/models/proxy.php
+++ b/models/proxy.php
@@ -3,26 +3,61 @@
 namespace Model\Proxy;
 
 use Model\Config;
+use PicoFeed\Config\Config as PicoFeedConfig;
+use PicoFeed\Filter\Filter;
 use PicoFeed\Client\Client;
-use PicoFeed\Client\ClientException;
+
+function isSecureConnection()
+{
+    return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+}
+
+function addProxyToLink($link) {
+
+    if (isSecureConnection() && strpos($link, 'http:') === 0) {
+        $link = '?action=proxy&url='.urlencode($link);
+    }
+
+    return $link;
+}
+
+function addProxyToTags($html, $website, $proxy_images, $cloak_referrer)
+{
+    if ($html === '' // no content, no proxy
+        || (! $cloak_referrer && ! $proxy_images) // neither cloaking nor proxing enabled
+        || (! $cloak_referrer && $proxy_images && ! isSecureConnection())) { // only proxy enabled, but not connected via HTTPS
+
+        return $html;
+    }
+
+    $config = new PicoFeedConfig();
+    $config->setFilterImageProxyUrl('?action=proxy&url=%s');
+
+    if (! $cloak_referrer && $proxy_images) {
+        // image proxy mode only: https links do not need to be proxied, since
+        // they do not trigger mixed content warnings.
+        $config->setFilterImageProxyProtocol('http');
+    }
+    elseif (! $proxy_images && $cloak_referrer && isSecureConnection() ) {
+        // cloaking mode only: if a request from a HTTPS connection to a HTTP
+        // connection is made, the referrer will be omitted by the browser.
+        // Only the referrer for HTTPS to HTTPs requests needs to be cloaked.
+        $config->setFilterImageProxyProtocol('https');
+    }
+
+    $filter = Filter::html($html, $website);
+    $filter->setConfig($config);
+
+    return $filter->execute();
+}
 
 function download($url)
 {
-    try {
-        $client = Client::getInstance();
-        $client->setUserAgent(Config\HTTP_USER_AGENT);
-        $client->execute($url);
+    $client = Client::getInstance();
+    $client->setUserAgent(Config\HTTP_USER_AGENT);
+    $client->enablePassthroughMode();
+    $client->execute($url);
 
-        $content = array(
-            $client->getContent(),
-            $client->getContentType(),
-        );
-    }
-    catch (ClientException $e) {
-        $content = array(false, false);
-    }
-
+    // does not work
     Config\write_debug();
-
-    return $content;
 }

--- a/models/schema.php
+++ b/models/schema.php
@@ -5,7 +5,12 @@ namespace Schema;
 use PDO;
 use Model\Config;
 
-const VERSION = 38;
+const VERSION = 39;
+
+function version_39($pdo)
+{
+    $pdo->exec('ALTER TABLE feeds ADD COLUMN cloak_referrer INTEGER DEFAULT 0');
+}
 
 function version_38($pdo)
 {

--- a/templates/add.php
+++ b/templates/add.php
@@ -19,6 +19,7 @@
 
     <?= Helper\form_checkbox('rtl', t('Force RTL mode (Right-to-left language)'), 1, isset($values['rtl']) ? $values['rtl'] : false) ?><br/>
     <?= Helper\form_checkbox('download_content', t('Download full content'), 1, isset($values['download_content']) ? $values['download_content'] : false) ?><br/>
+    <?= Helper\form_checkbox('cloak_referrer', t('Cloak the image referrer'), 1, isset($values['cloak_referrer']) ? $values['cloak_referrer'] : false) ?><br />
 
     <p class="form-help"><?= t('Downloading full content is slower because Miniflux grab the content from the original website. You should use that for subscriptions that display only a summary. This feature doesn\'t work with all websites.') ?></p>
     <div class="form-actions">

--- a/templates/edit_feed.php
+++ b/templates/edit_feed.php
@@ -25,6 +25,8 @@
 
     <?= Helper\form_checkbox('download_content', t('Download full content'), 1, isset($values['download_content']) ? $values['download_content'] : false) ?><br />
 
+    <?= Helper\form_checkbox('cloak_referrer', t('Cloak the image referrer'), 1, isset($values['cloak_referrer']) ? $values['cloak_referrer'] : false) ?><br />
+
     <?= Helper\form_checkbox('enabled', t('Activated'), 1, isset($values['enabled']) ? $values['enabled'] : false) ?>
 
     <div class="form-actions">

--- a/templates/show_item.php
+++ b/templates/show_item.php
@@ -81,11 +81,7 @@
                 </div>
                 <?php elseif (strpos($item['enclosure_type'], 'image') !== false && $item['content'] === ''): ?>
                 <div id="item-content-enclosure">
-                    <?php if ($image_proxy_enabled): ?>
-                        <img src="?action=proxy&amp;url=<?= urlencode($item['enclosure']) ?>" alt="enclosure"/>
-                    <?php else: ?>
-                        <img src="<?= $item['enclosure'] ?>" alt="enclosure"/>
-                    <?php endif ?>
+                    <img src="<?= $item['enclosure'] ?>" alt="enclosure"/>
                 </div>
                 <?php endif ?>
             <?php endif ?>

--- a/tests/integration/datasets/expected_BookmarkReadArticle.xml
+++ b/tests/integration/datasets/expected_BookmarkReadArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_BookmarkUnreadArticle.xml
+++ b/tests/integration/datasets/expected_BookmarkUnreadArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_FirstFeedAllRemoved.xml
+++ b/tests/integration/datasets/expected_FirstFeedAllRemoved.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_MarkFeedRead.xml
+++ b/tests/integration/datasets/expected_MarkFeedRead.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_MarkReadBookmarkedArticle.xml
+++ b/tests/integration/datasets/expected_MarkReadBookmarkedArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_MarkReadNotBookmarkedArticle.xml
+++ b/tests/integration/datasets/expected_MarkReadNotBookmarkedArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_MarkUnreadBookmarkedArticle.xml
+++ b/tests/integration/datasets/expected_MarkUnreadBookmarkedArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_MarkUnreadNotBookmarkedArticle.xml
+++ b/tests/integration/datasets/expected_MarkUnreadNotBookmarkedArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_NoBookmarkedArticles.xml
+++ b/tests/integration/datasets/expected_NoBookmarkedArticles.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_NoReadArticles.xml
+++ b/tests/integration/datasets/expected_NoReadArticles.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_NoReadNotBookmarkedArticles.xml
+++ b/tests/integration/datasets/expected_NoReadNotBookmarkedArticles.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_RemoveReadBookmarkedArticle.xml
+++ b/tests/integration/datasets/expected_RemoveReadBookmarkedArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_RemoveReadNotBookmarkedArticle.xml
+++ b/tests/integration/datasets/expected_RemoveReadNotBookmarkedArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_RemoveUnreadBookmarkedArticle.xml
+++ b/tests/integration/datasets/expected_RemoveUnreadBookmarkedArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_RemoveUnreadNotBookmarkedArticle.xml
+++ b/tests/integration/datasets/expected_RemoveUnreadNotBookmarkedArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_UnbookmarkReadArticle.xml
+++ b/tests/integration/datasets/expected_UnbookmarkReadArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/expected_UnbookmarkUnreadArticle.xml
+++ b/tests/integration/datasets/expected_UnbookmarkUnreadArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/fixture_OneUnreadArticle.xml
+++ b/tests/integration/datasets/fixture_OneUnreadArticle.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/fixture_OnlyReadArticles.xml
+++ b/tests/integration/datasets/fixture_OnlyReadArticles.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/fixture_feed1.xml
+++ b/tests/integration/datasets/fixture_feed1.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/fixture_feed1_parsing_error.xml
+++ b/tests/integration/datasets/fixture_feed1_parsing_error.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://miniflux.net/</value>
@@ -23,6 +24,7 @@
 			<value>1</value>
 			<value>0</value>
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 		</row>
 	</table>

--- a/tests/integration/datasets/fixture_feed2.xml
+++ b/tests/integration/datasets/fixture_feed2.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>2</value>
 			<value>https://github.com/fguillot/miniflux/commits/master</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>

--- a/tests/integration/datasets/fixture_feed_error_disabled_normal.xml
+++ b/tests/integration/datasets/fixture_feed_error_disabled_normal.xml
@@ -12,6 +12,7 @@
 		<column>download_content</column>
 		<column>parsing_error</column>
 		<column>rtl</column>
+		<column>cloak_referrer</column>
 		<row>
 			<value>1</value>
 			<value>http://www.01net.com/actus/</value>
@@ -21,6 +22,7 @@
 			<null />
 			<null />
 			<value>1</value>
+			<value>0</value>
 			<value>0</value>
 			<value>0</value>
 			<value>0</value>


### PR DESCRIPTION
- use passthrough mode for image proxy (fixes #295)
- add image proxy on article rendering (fixes #314)
- add referrer cloaking option to feed options (fixes #319)

There are two known issues:

1. All images that have the image proxy hard coded fail to display. This is a temporary issue, since only already fetched and rewritten content is affected. One way to bypass the issue, is to misuse the schema.php to remove the image proxy from the feed content. I've done nothing so far, since I'm unsure how many users are affected and if it's worse the work.
2. The debug logging does not work.